### PR TITLE
Update readme example to work right outta the box.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,9 @@ simple functions for doing oauth login with github. compatible with any node htt
 var githubOAuth = require('github-oauth')({
   githubClient: process.env['GITHUB_CLIENT'],
   githubSecret: process.env['GITHUB_SECRET'],
-  baseURL: 'http://localhost'
+  baseURL: 'http://localhost',
+  loginURI: '/login',
+  callbackURI: '/callback'
 })
 
 require('http').createServer(function(req, res) {


### PR DESCRIPTION
Adding loginURI and callbackURI to the options seems cleaner than including `github\/` with `req.url.match`
