### PR TITLE
package.json: fix engines warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
   "dependencies": {
     "request": "2.12.0"
   },
-  "engines": {
-    "node": "v0.8.x"
-  },
   "bugs": {
     "url": "https://github.com/maxogden/github-oauth/issues"
   },


### PR DESCRIPTION
It was throwing a warning during installation, this should fix it.

![screen shot 2014-08-24 at 14 06 03](https://cloud.githubusercontent.com/assets/2467194/4023329/5a3d9c6a-2b87-11e4-9879-61b799047d80.png)
