### PR TITLE
Use url.resolve over path.join

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var request = require('request')
 var events = require('events')
 var url = require('url')
-var path = require('path')
 var crypto = require('crypto')
 
 module.exports = function(opts) {
@@ -10,7 +9,7 @@ module.exports = function(opts) {
   if (!opts.scope) opts.scope = 'user'
   var state = crypto.randomBytes(8).toString('hex')
   var urlObj = url.parse(opts.baseURL)
-  urlObj.pathname = path.join(urlObj.pathname, opts.callbackURI)
+  urlObj.pathname = url.resolve(urlObj.pathname, opts.callbackURI)
   var redirectURI = url.format(urlObj)
   var emitter = new events.EventEmitter()
   


### PR DESCRIPTION
path.join does OS based path joining, on Windows this causes back slashes in the path which is not a valid url.
