### PR TITLE
Add an option to specify the 'state'

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ module.exports = function(opts) {
   if (!opts.callbackURI) opts.callbackURI = '/github/callback'
   if (!opts.loginURI) opts.loginURI = '/github/login'
   if (typeof opts.scope === 'undefined') opts.scope = 'user'
-  var state = crypto.randomBytes(8).toString('hex')
+  var state = opts.state == null
+    ? crypto.randomBytes(8).toString('hex')
+    : opts.state;
   var urlObj = url.parse(opts.baseURL)
   urlObj.pathname = url.resolve(urlObj.pathname, opts.callbackURI)
   var redirectURI = url.format(urlObj)


### PR DESCRIPTION
I've found that sometimes it's necessary to specify the state, for scenarios where the githubOauth object needs to be recreated on each request (which happens when the callback URL needs to be specified per instance of connecting to GitHub). The state can be specified as a JWT token, which is effectively random but can also be verified without storing state on the server.